### PR TITLE
Updated to use newer version of bitcoin-wallet/core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM gentoorax/xpra-base:latest
-MAINTAINER Chris Law <law1213@hotmail.com>
-ENV BTC_VERSION "0.15.1"
-ENV BTC_GUI_DOWNLOAD_URL https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-${BTC_VERSION}-x86_64-linux-gnu.tar.gz
+FROM juanluisbaptiste/xpra-base:latest
+MAINTAINER Juan Luis Baptiste <juan.baptiste@gmail.com>
+ENV BTC_VERSION "0.18.0"
+ENV BTC_GUI_DOWNLOAD_URL https://bitcoin.org/bin/bitcoin-core-0.18.0/bitcoin-${BTC_VERSION}-x86_64-linux-gnu.tar.gz
 COPY local-entrypoint.sh /
 
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM juanluisbaptiste/xpra-base:latest
-MAINTAINER Juan Luis Baptiste <juan.baptiste@gmail.com>
+FROM gentoorax/xpra-base:latest
+MAINTAINER Chris Law <law1213@hotmail.com>
 ENV BTC_VERSION "0.15.1"
 ENV BTC_GUI_DOWNLOAD_URL https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-${BTC_VERSION}-x86_64-linux-gnu.tar.gz
 COPY local-entrypoint.sh /


### PR DESCRIPTION
Download URL for that version no longer exists, so updated to use the latest version available from same location.